### PR TITLE
Add command to make a directory for each application

### DIFF
--- a/make_source_code_dirs.sh
+++ b/make_source_code_dirs.sh
@@ -1,0 +1,1 @@
+tidal export apps | jq  '.[] | "\(.id)-\(.name)"' | tr '[:upper:]' '[:lower:]' | tr -s ' /()' '____' | xargs mkdir


### PR DESCRIPTION
Useful for running source code analysis on every application in tidal. Will create a directory, in current directory, that is named based on the app name and app id.
