### PR TITLE
App Service Details

### DIFF
--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -160,6 +160,18 @@ module AzureAppServiceDetails
       to the current working directory in the format of:
       <app-service-name>_<app-service-resource-group-name>.json
 
+
+      How to Use
+
+      First authentication and set a token with the azure-cli using:
+
+      az login
+      az account set --subscription <SUBSCRIPTION_ID>
+      export AZURE_TOKEN=$(az account get-access-token --query accessToken --output tsv)
+
+      Run the command as above, for example:
+
+      #{$0}  <subscription-id>
     USAGE
   end
 

--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -152,7 +152,7 @@ module AzureAppServiceDetails
     dir = "subscription_#{subscription}_app_services"
     FileUtils.mkdir_p dir
     file_name = File.join dir, "#{app_service['name']}_#{app_service['properties']['resourceGroup']}.json"
-    File.write(file_name, app_service.to_json)
+    File.write(file_name, JSON.pretty_generate(app_service))
     puts "Entire App Service resource and Service Plan written to #{file_name}"
   end
 

--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -7,24 +7,24 @@ module AzureAppServiceApi
   end
 
   def list_app_services(subscription, resource_group)
-    azure_request(base_site(subscription, resource_group), :get, "2022-09-01")["value"]
+    azure_site(subscription, resource_group, "/", :get, "2022-09-01")["value"]
   end
 
-  def list_service_plans(subscription)
-    azure_request "#{base_rg(subscription, resource_group)}/serverfarms"
+  def list_service_plans(subscription, resource_group)
+    azure_rg(subscription, resource_group, "/serverfarms")
   end
 
   def get_app_service(subscription, name, resource_group)
-    azure_request "#{base_site(subscription, resource_group)}/#{name}"
+    azure_site(subscription, resource_group, "/#{name}")
   end
 
   def connection_strings(subscription, resource_group, app_name)
-    azure_request "#{base_site(subscription, resource_group)}/#{app_name}/config/connectionstrings/list", :post
+    azure_site(subscription, resource_group, "#{app_name}/config/connectionstrings/list", :post)
   end
 
   # currently not returning needed Appsettings values
   def list_app_configs(subscription, resource_group, app_name)
-    azure_request "#{base_site(subscription, resource_group)}/#{app_name}/config/web"
+    azure_site(subscription, resource_group, "/#{app_name}/config/web")
     # returns similar result but appSettings empty as well
     # azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/" \
     #               "Microsoft.Web/sites/#{app_name}/config"
@@ -32,13 +32,13 @@ module AzureAppServiceApi
 
   # currently not returning needed Appsettings values
   def app_settings(subscription, resource_group, app_name)
-    azure_request "#{base_site(subscription, resource_group)}/#{app_name}/config/appsettings/list"
+    azure_site(subscription, resource_group, "/#{app_name}/config/appsettings/list")
   end
 
   # redundant, not needed, URL for this resource returned with app service object
   # also note, 'server farm' is analogous for 'service plan'
   def server_farms(subscription, resource_group, app_service_plan_name)
-    azure_request "#{base_rg(subscription, resource_group)}/serverfarms/#{app_service_plan_name}"
+    azure_rg subscription, resource_group, "serverfarms/#{app_service_plan_name}"
   end
 
   def app_service_service_plan(app_service)
@@ -51,8 +51,16 @@ module AzureAppServiceApi
   end
 
   # can only query with a worker_pool name value
-  def private_endpoint_connections(sub, resource_group, name)
-    azure_request "#{base_rg(sub, resource_group)}/hostingEnvironments/#{name}/privateEndpointConnections"
+  def private_endpoint_connections(subscription, resource_group, name)
+    azure_rg subscription, resource_group, "/hostingEnvironments/#{name}/privateEndpointConnections"
+  end
+
+  def azure_rg(subscription, resource_group, path)
+    azure_request "#{base_rg(subscription, resource_group)}/#{path}"
+  end
+
+  def azure_site(subscription, resource_group, path, method = :get, version = "2022-03-01")
+    azure_request "#{base_site(subscription, resource_group)}/#{path}", method, version
   end
 
   def base_site(subscription, resource_group)

--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -18,7 +18,7 @@ module AzureAppServiceApi
   end
 
   # API Documentation - https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/list-connection-strings?view=rest-appservice-2022-03-01
-  def connection_strings(subscription, resource_group, app_name)
+  def list_connection_strings(subscription, resource_group, app_name)
     azure_site(subscription, resource_group, "#{app_name}/config/connectionstrings/list", :post)
   end
 
@@ -30,12 +30,6 @@ module AzureAppServiceApi
   # API Documentation - https://learn.microsoft.com/en-us/rest/api/appservice/app-service-plans/get?view=rest-appservice-2022-03-01&tabs=HTTP
   def app_service_service_plan(app_service)
     azure_request app_service["properties"]["serverFarmId"]
-  end
-
-  # Makes a request to Azure API at a base path of:
-  # /subscriptions/:id/resourceGroups/:name/providers/Microsoft.Web
-  def azure_rg(subscription, resource_group, path)
-    azure_request "#{base_rg(subscription, resource_group)}/#{path}"
   end
 
   # Makes a request to Azure API at a base path of:
@@ -105,9 +99,11 @@ module AzureAppServiceDetails
 
   def app_service_details(sub, app_service)
     app_service["service_plan"] = app_service_service_plan(app_service)
-    app_service["app_connection_strings"] = connection_strings(sub, app_service["properties"]["resourceGroup"],
-                                                               app_service["name"])
-    app_service["app_settings"] = list_app_settings(sub, app_service["properties"]["resourceGroup"], app_service["name"])
+    app_service["app_connection_strings"] = list_connection_strings(sub, app_service["properties"]["resourceGroup"],
+                                                                    app_service["name"])
+    app_service["app_settings"] = list_app_settings(sub,
+                                                    app_service["properties"]["resourceGroup"],
+                                                    app_service["name"])
     app_service
   end
 

--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -1,41 +1,54 @@
 #!/bin/env ruby
+module AzureAppServiceApi
+  require "net/http"
 
-require "./azure_migrate.rb"
-require "./azure_vms.rb"
-require 'fileutils'
+  def list_resource_groups(subscription)
+    azure_request("/subscriptions/#{subscription}/resourcegroups", :get, "2023-07-01")["value"]
+  end
 
-module AzureAppServiceDetails
-  include AzureMigrate
-  include AzureAppService
-
-  # to get resource groups
-  include AzureVM
+  def list_app_services(subscription, resource_group_name)
+    azure_request("/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites",
+                  :get, "2022-09-01")["value"]
+  end
 
   def list_service_plans(subscription_id)
     azure_request "/subscriptions/#{subscription_id}/providers/Microsoft.Web/serverfarms"
   end
 
   def get_app_service(subscription, name, resource_group_name)
-    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites/#{name}"
-  end
-
-  def list_app_configs(subscription, resource_group_name, app_name)
-    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites/#{app_name}/config/web"
-    # returns similar result but appSettings empty as well
-    #azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites/#{app_name}/config"
-  end
-
-  def app_settings(subscription, resource_group_name, app_name)
-    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites/#{app_name}/config/appsettings/list"
+    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/" \
+                  "Microsoft.Web/sites/#{name}"
   end
 
   def connection_strings(subscription, resource_group_name, app_name)
-    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites/#{app_name}/config/connectionstrings/list", :post
+    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/" \
+                  "Microsoft.Web/sites/#{app_name}/config/connectionstrings/list", :post
+  end
+
+  # currently not returning needed Appsettings values
+  def list_app_configs(subscription, resource_group_name, app_name)
+    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/" \
+                  "Microsoft.Web/sites/#{app_name}/config/web"
+    # returns similar result but appSettings empty as well
+    # azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/" \
+    #               "Microsoft.Web/sites/#{app_name}/config"
+  end
+
+  # currently not returning needed Appsettings values
+  def app_settings(subscription, resource_group_name, app_name)
+    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/" \
+                  "Microsoft.Web/sites/#{app_name}/config/appsettings/list"
   end
 
   # redundant, not needed, URL for this resource returned with app service object
+  # also note, 'server farm' is analogous for 'service plan'
   def server_farms(subscription_id, group_name, app_service_plan_name)
-    azure_request "/subscriptions/#{subscription_id}/resourceGroups/#{group_name}/providers/Microsoft.Web/serverfarms/#{app_service_plan_name}"
+    azure_request "/subscriptions/#{subscription_id}/resourceGroups/#{group_name}/providers/" \
+                  "Microsoft.Web/serverfarms/#{app_service_plan_name}"
+  end
+
+  def app_service_service_plan(app_service)
+    azure_request app_service["properties"]["serverFarmId"]
   end
 
   # empty as of now with current demo setup
@@ -43,22 +56,21 @@ module AzureAppServiceDetails
     azure_request "/subscriptions/#{sub}/providers/Microsoft.Web/hostingEnvironments"
   end
 
-  # can't query without worker_pool name value
+  # can only query with a worker_pool name value
   def private_endpoint_connections(sub, resource_group, name)
-    azure_request "/subscriptions/#{sub}/resourceGroups/#{resource_group}/providers/Microsoft.Web/hostingEnvironments/#{name}/privateEndpointConnections"
+    azure_request "/subscriptions/#{sub}/resourceGroups/#{resource_group}/providers/" \
+                  "Microsoft.Web/hostingEnvironments/#{name}/privateEndpointConnections"
   end
 
-  def azure_request(path, method = :get)
+  def azure_request(path, method = :get, version = "2022-03-01")
     JSON.parse(make_request(method:       method,
-                            path:         "#{base_url}#{path}",
+                            path:         "https://management.azure.com#{path}",
                             body:         nil,
-                            query_params: { "api-version": "2022-03-01" },
-                            headers:      { "Authorization" => "Bearer #{get_token}" }).response.body)
+                            query_params: { "api-version": version },
+                            headers:      { "Authorization" => "Bearer #{ENV.fetch('AZURE_TOKEN')}" }).response.body)
   end
 
   def make_request(method:,path:, query_params: {}, body: {}, headers: {}, form: [], ssl: true, timeout: 60, basic_auth: [])
-    raise ArgumentError, "Must provide a valid method: #{valid_methods}" unless valid_methods.include? method.downcase
-
     uri, http = get_uri_http(path:         path,
                              ssl:          ssl,
                              query_params: query_params)
@@ -77,15 +89,30 @@ module AzureAppServiceDetails
     http.request(request)
   end
 
+  def get_uri_http(path:, query_params: nil, ssl: true)
+    uri = URI(path)
+    uri.query = URI.encode_www_form query_params if query_params
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = ssl
+    [uri, http]
+  end
+end
+
+module AzureAppServiceDetails
+  require "fileutils"
+  require "json"
+  include AzureAppServiceApi
+
   def all_app_services(subscription)
     list_resource_groups(subscription).map do |resource_group|
-      list_app_services(subscription, resource_group)
+      list_app_services(subscription, resource_group["name"])
     end.flatten
   end
 
   def app_service_details(sub, app_service)
-    app_service["service_plan"] = azure_request app_service["properties"]["serverFarmId"]
-    app_service["app_connection_strings"] = connection_strings(sub, app_service["properties"]["resourceGroup"], app_service["name"])
+    app_service["service_plan"] = app_service_service_plan(app_service)
+    app_service["app_connection_strings"] = connection_strings(sub, app_service["properties"]["resourceGroup"],
+                                                               app_service["name"])
     app_service["app_configs"] = list_app_configs(sub, app_service["properties"]["resourceGroup"], app_service["name"])
     app_service
   end
@@ -132,16 +159,13 @@ module AzureAppServiceDetails
   end
 
   def output_app_service(subscription, name)
-    get_details_and_output(subscription, all_app_services(subscription).select { |app_service| app_service["name"] == name }.first)
+    get_details_and_output(subscription, all_app_services(subscription)
+                                         .select { |app_service| app_service["name"] == name }.first)
   end
+end
 
-  def output_first_app_service(subscription)
-    get_details_and_output(subscription, all_app_services(subscription).first)
-  end
-
-  # notes
-  # appsettings is blank - may not be possible? - https://github.com/MicrosoftDocs/azure-docs/issues/38698
-  # testing subscription '4c1a8af4-85cb-44c7-9528-491d3848d341'
+class Cli
+  include AzureAppServiceDetails
 
   def output_usage
     puts <<~USAGE
@@ -149,34 +173,25 @@ module AzureAppServiceDetails
 
       Usage:
 
-      Retrieve all App Service's in a given subscription:
-      #{$PROGRAM_NAME} <subscription-id>
-
-
-      Retrieve a single App Service's:
-      #{$PROGRAM_NAME} <subscription-id> <app-service-name>
-
-
-      The output will include a summary to standard output as well as a file written
-      to the new directory in the current working directory in the format of:
-      ./subscription_<subscription-id>_app_services/<app-service-name>_<app-service-resource-group-name>.json
-
-
-      How to Use
-
-      First authentication and set a token with the azure-cli using:
+      First authenticate with Azure and set a token via the azure-cli using:
 
       az login
       az account set --subscription <SUBSCRIPTION_ID>
       export AZURE_TOKEN=$(az account get-access-token --query accessToken --output tsv)
 
-      Run the command as above, for example:
+      Retrieve all App Service's in a given subscription:
+      #{$PROGRAM_NAME} <subscription-id>
 
-      #{$0}  <subscription-id>
+      Retrieve a single App Service's:
+      #{$PROGRAM_NAME} <subscription-id> <app-service-name>
+
+      The output will include a summary to standard output as well as a file written
+      to the new directory in the current working directory in the format of:
+      ./subscription_<subscription-id>_app_services/<app-service-name>_<app-service-resource-group-name>.json
     USAGE
   end
 
-  def cli_execute
+  def execute
     case ARGV.length
     when 1
       output_all_app_services(ARGV[0])
@@ -188,5 +203,4 @@ module AzureAppServiceDetails
   end
 end
 
-include AzureAppServiceDetails
-cli_execute
+Cli.new.execute

--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -1,0 +1,117 @@
+require "./azure_migrate.rb"
+require "./azure_vms.rb"
+
+module AzureAppServiceDetails
+  include AzureMigrate
+  include AzureAppService
+
+  def list_service_plans(subscription_id)
+    azure_request "/subscriptions/#{subscription_id}/providers/Microsoft.Web/serverfarms"
+  end
+
+  def get_app_service(name, resource_group_name)
+    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites/#{name}"
+  end
+
+  def app_settings(subscription, resource_group_name, app_name)
+    azure_request "/subscriptions/#{subscription}/resourceGroups/#{resource_group_name}/providers/Microsoft.Web/sites/#{app_name}/config/appsettings/list"
+  end
+
+  # redundant, not needed
+  def server_farms(subscription_id, group_name, app_service_plan_name)
+    azure_request "/subscriptions/#{subscription_id}/resourceGroups/#{group_name}/providers/Microsoft.Web/serverfarms/#{app_service_plan_name}"
+  end
+
+  # empty as of now with current demo setup
+  def worker_pools(sub)
+    azure_request "/subscriptions/#{sub}/providers/Microsoft.Web/hostingEnvironments"
+  end
+
+  # can't query without worker_pool name value
+  def private_endpoint_connections(sub, resource_group, name)
+    azure_request "/subscriptions/#{sub}/resourceGroups/#{resource_group}/providers/Microsoft.Web/hostingEnvironments/#{name}/privateEndpointConnections"
+  end
+
+  def azure_request(path)
+    JSON.parse(make_request(method:       :get,
+                            path:         "#{base_url}#{path}",
+                            body:         nil,
+                            query_params: { "api-version": "2022-03-01" },
+                            headers:      { "Authorization" => "Bearer #{get_token}" }).response.body)
+  end
+
+  def make_request(method:,path:,
+    query_params: {},
+    body: {},
+    headers: {},
+    form: [],
+    ssl: true,
+    timeout: 60,
+    basic_auth: [])
+    raise ArgumentError, "Must provide a valid method: #{valid_methods}" unless valid_methods.include? method.downcase
+
+    uri, http = get_uri_http(path:         path,
+                             ssl:          ssl,
+                             query_params: query_params)
+    request = Object.const_get("Net::HTTP::#{method.downcase.capitalize}").new(uri.request_uri)
+    request.basic_auth(*basic_auth) unless basic_auth.empty?
+
+    if form || form.empty?
+      request.body = body
+    else
+      request.set_form(*form)
+    end
+
+    http.read_timeout = timeout
+    headers.each { |k, v| request[k] = v }
+
+    http.request(request)
+  end
+
+  def subscription
+    '4c1a8af4-85cb-44c7-9528-491d3848d341'
+  end
+
+  def resource_group
+    "app-service-demo"
+  end
+
+  def all_app_services
+    list_app_services(subscription, resource_group)
+  end
+
+  def first_name_and_resource_group
+    all = all_app_services
+    [all.first["name"], all.first["properties"]["resourceGroup"]]
+  end
+
+  def app_service_details(app_service_name, resource_group_name)
+    app = get_app_service(app_service_name, resource_group_name)
+    service_plan = azure_request app["properties"]["serverFarmId"]
+    [app, service_plan]
+  end
+
+  def output_details(app, service_plan)
+    site_config = app["properties"]["siteConfig"]
+    pp "APP SERVICE RESOURCE ---#{app["name"]}------"
+    pp app
+    pp "SERVICE PLAN ---------------------------"
+    pp service_plan
+    puts "\n\n"
+    pp "CONNECTION STRINGS ---------------------"
+    pp site_config["connectionStrings"]
+    pp "APP Settings ---------------------------"
+    pp site_config["appSettings"]
+    pp "STORAGE ACCOUNTS -----------------------"
+    pp site_config["azureStorageAccounts"]
+    pp "SKU ----------------------------------- "
+    pp service_plan["sku"]
+  end
+
+  def first_details
+    name, resource_group = first_name_and_resource_group
+    details = app_service_details(name, resource_group)
+    File.write("#{name}_#{resource_group}.json", details.to_json)
+    output_details(*details)
+  end
+end

--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -108,12 +108,10 @@ module AzureAppServiceDetails
   end
 
   def summary_app(app)
-    site_config = app["properties"]["siteConfig"]
     { name:               app["name"],
       resource_group:     app["properties"]["resourceGroup"],
       connection_strings: app["app_connection_strings"]["properties"].keys,
       app_settings:       app["app_settings"]["properties"].keys,
-      storage_accounts:   site_config["azureStorageAccounts"],
       service_plan_sku:   app["service_plan"]["sku"] }
   end
 


### PR DESCRIPTION
## Requirements, Needs and Design 
Given an Azure subscription with many applications running on App Service, and various databases. Need a way to determine which infrastructure, specifically databases are dependencies for which applications. As well as a way to determine the specifications and resource utilization of the App Service. The constraint is that we can only query the Azure API, with no access to any of the running services or infrastructure. We also require that there is a separation of responsibility between who can access the Azure API in the environment and who needs to assess and analyze the results. There is also the consideration that this information, specifically connection string values, includes sensitive information. 

Given these needs, it is designed with these needs in mind. It can be executed and gather all information in one command from an entire subscription, or select services specified. The request information can be validated with the on-screen output. All the data queried can be easily provided to another individual from one directory of results without requiring Azure access. Given the need of customers needing to execute it themselves, who may not necessarily have direct access connectivity or authorization to a Tidal Workspace, and given that the included data contains sensitive information, it is designed to not synchronize any data with Tidal Accelerator directly.

Implementation, there is currently overlap in some functionality in other Ruby scripts. Due to them being executable as is, they can not be used here directly without refactoring them. Also, due to how these are executed and installed by end users as single scripts, introducing dependencies between several script files increases the effort and makes it more difficult to execute, requiring all dependent files to be present. Last, several methods from other ruby scripts that use the Azure API, failed to execute, specifically in making HTTP requests via `azure_request`, while others did not behave as needed for the API requests needed. For all these reasons, this script was implemented independently of any external scripts. A working branch containing usage and coupling between script files [is here for future](https://github.com/tidalmigrations/gists/pull/21).

## What it does
Takes a subscription ID and will return data on all App Services in that subscription. OR Takes a subscription ID and app service name and returns data for that one app service.

After data is collected from the API, the values for connection strings and application settings are modified, before the results are written to a file. This is an attempt to remove any credentials from the values and not expose them.

## What is missing
~The one requirement that is missing is retrieving connection string information for any Redis databases. These values are stored in the appSettings for an App Service. It appears there is an issue in the Azure API and it fails to return any values for appSettings. You will see in this demo that the values are null, however, the portal contains values. I have an open support request with Microsoft to resolve.~

One minor difference in requirements, the user input requires providing an App Service name as well as a subscription ID, to retrieve all the info, and not only an App Service name.

It currently is limited in error handling and error feedback. That can be improved in future changes.  

## The output
On-screen it outputs a summary of the app service (or multiple), including name resource group, connection string names, app settings names, (Not values as those are sensitive), and service plan SKU info.
- The connectionString values are what contain any database (non-Redis) connection details and hostnames. 
- The appSettings should include any Redis database connection information. 
- The SKU information contains sizing and specification details. 
- There are many other attributes that all determine various configurations and sizes.

It will write to a file named appropriately, one file for each app service. The entire app service resource and service plan resource, which includes ~100s of attributes.

Sample output file - 
[tidal-demo_app-service-demo.json](https://github.com/tidalmigrations/gists/files/13639914/tidal-demo_app-service-demo.json)

## How to use
Authenticate -
- `az login`
- `az account set --subscription <SUBSCRIPTION_ID>`
- `export AZURE_TOKEN=$(az account get-access-token --query accessToken --output tsv)`

Execute with a subscription ID, or a subscription ID and an App Service name. Output includes resources written to the files mentioned.

```
❯ ./azure_app_service_details.rb 4c1a8af4-85cb-44c7-9528-491d3848d341  tidal-demo   
Entire App Service resource and Service Plan written to subscription_4c1a8af4-85cb-44c7-9528-491d3848d341_app_services/tidal-demo_app-service-demo.json

{
  "name": "tidal-demo",
  "resource_group": "app-service-demo",
  "connection_strings": [
    "AZURE_POSTGRESQL_CONNECTIONSTRING",
    "test"
  ],
  "app_settings": [
    "AZURE_REDIS_CONNECTIONSTRING",
    "testappsetting"
  ],
  "service_plan_sku": {
    "name": "B1",
    "tier": "Basic",
    "size": "B1",
    "family": "B",
    "capacity": 1
  }
}

------------------------------------------


❯ ./azure_app_service_details.rb 4c1a8af4-85cb-44c7-9528-491d3848d341            
Entire App Service resource and Service Plan written to subscription_4c1a8af4-85cb-44c7-9528-491d3848d341_app_services/tidal-demo_app-service-demo.json

{
  "name": "tidal-demo",
  "resource_group": "app-service-demo",
  "connection_strings": [
    "AZURE_POSTGRESQL_CONNECTIONSTRING",
    "test"
  ],
  "app_settings": [
    "AZURE_REDIS_CONNECTIONSTRING",
    "testappsetting"
  ],
  "service_plan_sku": {
    "name": "B1",
    "tier": "Basic",
    "size": "B1",
    "family": "B",
    "capacity": 1
  }
}

------------------------------------------


```

## TODO
- [x] Setup invocation via CLI with configurable arguments  provided
- [x] iterate all app services and return a list of all of their names and their resource groups - this will allow the removal of the current requirement of needing to provide both an app service name and its resource group name. 
- [x] Refactor and clean up API invocation. Duplicated and differs between all uses
- [x] determine why connectionStrings are blank. connectionStrings has connectionDetails for Postgres. - For this specific example. Potentially related to them being sensitive and encrypted and therefore not included in these requests.
- [x] appSettings are blank. when compared to the portal, where they have values listed. Specifically, appSettings has a connection detail for Redis. Pending Microsoft support.
    - At least 3 of the endpoints that include appSettings information all contain `null` and no values. Only one endpoint does return the values as expected and documented. Either the documentation is wrong, or the behaviour of the API is not working as documented. See here for the endpoints -https://github.com/MicrosoftDocs/azure-docs/issues/38698#issuecomment-1850334844