### PR TITLE
Include databases in output

### DIFF
--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -118,6 +118,38 @@ module AzureAppServiceDetails
   require "json"
   include AzureAppServiceApi
 
+  def required_role_json
+    <<~ROLE
+      {
+          "properties": {
+              "roleName": "AppServiceAndDatabasesRead",
+              "description": "Read access to several Databases resources, and App Services including sensitive information.",
+              "assignableScopes": [
+                  "/subscriptions/ADD-SUBSCRIPTION-ID-HERE"
+              ],
+              "permissions": [
+                  {
+                      "actions": [
+                          "Microsoft.Resources/subscriptions/resourceGroups/read",
+                          "Microsoft.Web/sites/Read",
+                          "Microsoft.Web/sites/config/list/Action",
+                          "Microsoft.Web/serverfarms/Read",
+                          "Microsoft.Sql/managedInstances/read",
+                          "Microsoft.Sql/servers/read",
+                          "Microsoft.DBforPostgreSQL/flexibleServers/read",
+                          "Microsoft.DBforMySQL/flexibleServers/read",
+                          "Microsoft.Cache/redis/read"
+                      ],
+                      "notActions": [],
+                      "dataActions": [],
+                      "notDataActions": []
+                  }
+              ]
+          }
+      }
+    ROLE
+  end
+
   def all_app_services(subscription)
     list_resource_groups(subscription).map do |resource_group|
       list_app_services(subscription, resource_group["name"])
@@ -270,6 +302,12 @@ class Cli
       to the new directory in the current working directory in the format of:
       ./subscription_<subscription-id>/app_services/<app-service-name>_<app-service-resource-group-name>.json
       ./subscription_<subscription-id>/databases/<database-type>.json
+
+      Required Azure API Access
+
+      The following role includes all of the needed permissions to run this script:
+
+      #{required_role_json}
     USAGE
   end
 

--- a/azure_app_service_details.rb
+++ b/azure_app_service_details.rb
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 module AzureAppServiceApi
   require "net/http"
 


### PR DESCRIPTION
This adds the addition of querying and saving the results of 5 different types of databases, including;
 database_managed_instances, database_servers, postgres_flexible_servers, mysql_flexible_servers, redis_databases

One notable change introduced here to the existing functionality is the structure of the file outputs. Now the file outputs are structured as such:

```
./subscription_<subscription-id>/app_services/<app-service-name>_<app-service-resource-group-name>.json
./subscription_<subscription-id>/databases/<database-type>.json
```
A secondary set of folders was added, one for app_services and one for databases. As well as a renaming and removal of app_services from the top-level folder. This maintains that all output files are in 1 folder, while also maintaining that 
the naming of the folders and files are representative of what they contain.

Using a default and standard app service creation from the portal, with a postgres and redis DB during creation. These DBs are confirmed to be present under the postgres_flexible_servers and redis_databases responses and output files. Sample output files from the demo (below) - 
- [redis_databases.json](https://github.com/tidalmigrations/gists/files/13663448/redis_databases.json)
- [postgres_flexible_servers.json](https://github.com/tidalmigrations/gists/files/13663449/postgres_flexible_servers.json)
- [mysql_flexible_servers.json](https://github.com/tidalmigrations/gists/files/13663450/mysql_flexible_servers.json)
- [database_servers.json](https://github.com/tidalmigrations/gists/files/13663451/database_servers.json)
- [database_managed_instances.json](https://github.com/tidalmigrations/gists/files/13663452/database_managed_instances.json)


Note this is potentially not exhaustive of all databases services or types that can be queried for from the API. The Azure API segments different types within services and services by various names and endpoints. Its likely other database resources could also be queried for. This is why the output filenames and usage text specify the specific types of databases that are queried for to help avoid potential confusion.
 
This PR also;
- improves the shebang line to follow the more conventional path.
- includes the needed Azure API permissions and example custom role that can be used.

Demo of usage and output - [recording](https://github.com/tidalmigrations/gists/assets/6665997/c6935959-0865-4329-b4ca-bb1cdcca3ed3)