### PR TITLE
Update gists to match new environment naming for sync endpoint

### DIFF
--- a/azure_dbs.rb
+++ b/azure_dbs.rb
@@ -148,7 +148,7 @@ module AzureDBServer
     db_server[:host_name] = server["name"] || server[:name]
     fqdn = properties.fetch("fullyQualifiedDomainName", nil)
     db_server[:fqdn] = fqdn if fqdn
-    db_server[:environment] = extract_environment_tag(server["tags"]) if server["tags"]
+    db_server[:environment] = { name: extract_environment_tag(server["tags"]) } if server["tags"]
     custom_fields.merge!(extract_azure_tags_as_custom_fields(server["tags"])) if server["tags"]
     db_server[:custom_fields] = custom_fields
     db_server
@@ -166,7 +166,7 @@ module AzureDBServer
     elastic_pool[:host_name] = pool["name"] || pool[:name]
     fqdn = properties.fetch("fullyQualifiedDomainName", nil)
     elastic_pool[:fqdn] = fqdn if fqdn
-    elastic_pool[:environment] = extract_environment_tag(pool["tags"]) if pool["tags"]
+    elastic_pool[:environment] = { name: extract_environment_tag(pool["tags"]) } if pool["tags"]
     custom_fields.merge!(extract_azure_tags_as_custom_fields(pool["tags"])) if pool["tags"]
     elastic_pool[:custom_fields] = custom_fields
     elastic_pool
@@ -416,7 +416,7 @@ class DBFetcher
       db_object[:description] = "Azure SQL Database"
       db_object[:server] = { host_name: db[:server_name] }
       db_object[:server_id] = db[:server_id]
-      db_object[:environment] = environment if environment
+      db_object[:environment] = { name: environment } if environment
       db_object[:custom_fields] = custom_fields
 
       # STDERR.puts "## Transformed database: #{db_object.inspect}"

--- a/azure_vms.rb
+++ b/azure_vms.rb
@@ -266,7 +266,9 @@ module AzureVM
         az_id: vm["id"],
         state: vm.dig("properties", "provisioningState"), 
         custom_fields: custom_fields_from_tags,
-        environment: environment
+        environment: {
+          name: environment
+        }
       }
     end
   end
@@ -357,7 +359,9 @@ module AzureVM
               az_vmSize: vm[:vm_size],
               state: vm[:state]
             }.merge(vm[:custom_fields]),
-            environment: vm[:environment],
+            environment: {
+              name: vm[:environment],
+            },
             ram_allocated_gb: size_details['memoryInMB'] ? (size_details['memoryInMB'] / 1024).to_i : nil,
             cpu_count: size_details['numberOfCores'] || "N/A",
             storage_allocated_gb: vm[:storage_allocated_gb] || "N/A",
@@ -414,7 +418,9 @@ module AzureAppService
       operating_system: app_service.dig("properties", "linuxFxVersion") ? "Linux" : "Windows",
       tags: app_service["tags"],
       fqdn: fqdn,
-      environment: environment,
+      environment: {
+        name: environment
+      },
       custom_fields: {
         siteId: app_service["id"],
         state: app_service.dig("properties", "state"),


### PR DESCRIPTION
The Sync endpoints in Tidal now expect environments to be of the form `{name: string}` instead of just `string`.
This is to match up with this PR
https://gitlab.com/subdata/application-inventory/-/merge_requests/1997/diffs